### PR TITLE
added collective coverage Python script to work with counter BBid

### DIFF
--- a/collective_coverage.py
+++ b/collective_coverage.py
@@ -1,11 +1,13 @@
 import inspect
 import getopt
+import pathlib
 import sys
 import os
 
 
 def get_full_path(filename):
-    current_file_path = os.path.dirname(os.path.abspath(inspect.getfile(inspect.currentframe())))
+    current_file_path = pathlib.Path(__file__).parent.absolute()
+    # current_file_path = os.path.dirname(os.path.abspath(inspect.getfile(inspect.currentframe())))
     return os.path.join(current_file_path, filename)
 
 
@@ -43,7 +45,7 @@ def run_program_on_tests(input_dir, output_dir, object_file):
         input_file = os.path.join(input_dir, input_name)
         input_name = input_name.strip().split('.')[0]
         if not os.path.isfile(input_file):
-            continue
+            sys.exit("Input directory should only include input seed files and no directories.")
         coverage_file = os.path.join(output_dir, "%s_%s_coverage.txt" % (object_file_name, input_name))
         os.system('%s -o %s  -A %s -- %s @@' %(bb_coverage_path, coverage_file, input_file, object_file))
 
@@ -54,7 +56,7 @@ def calculate_collective_coverage(output_dir, collective_coverage_path):
     for coverage_file_name in os.listdir(output_dir):
         coverage_file_path = os.path.join(output_dir, coverage_file_name)
         if not os.path.isfile(coverage_file_path):
-            continue
+            sys.exit("Output directory should only include output coverage files and should be empty before running this script.")
         seed_count += 1
         with open(coverage_file_path) as coverage_file:
             for line in coverage_file:

--- a/collective_coverage.py
+++ b/collective_coverage.py
@@ -7,7 +7,6 @@ import os
 
 def get_full_path(filename):
     current_file_path = pathlib.Path(__file__).parent.absolute()
-    # current_file_path = os.path.dirname(os.path.abspath(inspect.getfile(inspect.currentframe())))
     return os.path.join(current_file_path, filename)
 
 

--- a/collective_coverage.py
+++ b/collective_coverage.py
@@ -1,0 +1,89 @@
+import inspect
+import getopt
+import sys
+import os
+
+
+def get_full_path(filename):
+    current_file_path = os.path.dirname(os.path.abspath(inspect.getfile(inspect.currentframe())))
+    return os.path.join(current_file_path, filename)
+
+
+def process_arguments(argv):
+
+    try:
+        opts, args = getopt.getopt(argv,"hi:o:f:c:",[])
+
+    except getopt.GetoptError:
+        sys.exit('collective_coverage.py -i <input_dir_with_test_cases> -o <output_dir> -f <program_object_file_path> -c <collective_coverage_file> ')
+
+    for opt, arg in opts:
+        if opt == '-h':
+            print('collective_coverage.py -i <input_dir_with_test_cases> -o <output_dir> -f <program_object_file_path> -c <collective_coverage_file>')
+            sys.exit()
+        elif opt == '-i':
+            input_dir = arg
+        elif opt == '-o':
+            output_dir = arg
+        elif opt == '-f':
+            object_file = arg
+        elif opt == '-c':
+            collective_coverage_path = arg
+            
+    return input_dir, output_dir, object_file, collective_coverage_path
+
+
+def run_program_on_tests(input_dir, output_dir, object_file):
+
+    bb_coverage_path = get_full_path('./counter_BBid_coverage')
+    test_inputs = os.listdir(input_dir)
+    object_file_name = object_file.strip().split('/')[-1].split('.')[0]
+
+    for input_name in test_inputs:
+        input_file = os.path.join(input_dir, input_name)
+        input_name = input_name.strip().split('.')[0]
+        if not os.path.isfile(input_file):
+            continue
+        coverage_file = os.path.join(output_dir, "%s_%s_coverage.txt" % (object_file_name, input_name))
+        os.system('%s -o %s  -A %s -- %s @@' %(bb_coverage_path, coverage_file, input_file, object_file))
+
+
+def calculate_collective_coverage(output_dir, collective_coverage_path):
+    coverage_map = {}
+    seed_count = 0
+    for coverage_file_name in os.listdir(output_dir):
+        coverage_file_path = os.path.join(output_dir, coverage_file_name)
+        if not os.path.isfile(coverage_file_path):
+            continue
+        seed_count += 1
+        with open(coverage_file_path) as coverage_file:
+            for line in coverage_file:
+                coverage_list = line.strip().split(":")
+                if len(coverage_list) != 2:
+                    print('Invalid output file format in %s. Format should be "block id: coverage count" in each line.')
+                    continue
+                block_id, coverage = coverage_list[0], coverage_list[1]
+                if block_id not in coverage_map:
+                    coverage_map[block_id] = []
+                coverage_map[block_id].append(coverage)
+
+    if seed_count == 0:
+        sys.exit("No valid test seeds were found.")
+
+    with open(collective_coverage_path, 'w') as collective_coverage_file:
+        for block_id in coverage_map:
+            coverage_percentage = float(len(coverage_map[block_id]))/seed_count
+            collective_coverage_file.write("%s:%f\n" %(block_id, coverage_percentage))
+
+
+if __name__ == "__main__":
+    input_dir, output_dir, object_file, collective_coverage_path = process_arguments(sys.argv[1:])
+
+    if not os.path.isdir(input_dir):
+        sys.exit("The input directory does not exist or is not a directory.")
+
+    if not os.path.isdir(output_dir):
+        sys.exit("The output directory does not exist or is not a directory.")
+
+    run_program_on_tests(input_dir, output_dir, object_file)
+    calculate_collective_coverage(output_dir, collective_coverage_path)

--- a/llvm_mode/afl-llvm-pass.so.cc
+++ b/llvm_mode/afl-llvm-pass.so.cc
@@ -79,6 +79,28 @@ SmallString<32> getmd5(std::string input){
 char AFLCoverage::ID = 0;
 
 
+u64 getBBCounter(BasicBlock *BB) {
+  MDNode* BBid_meta;
+  u64 block_counter;
+  if (BB->size() == 0)
+    FATAL("There is a basic block with no instructions in the program.");
+  for (Instruction& instr : BB->getInstList()) {
+        if (!instr.hasMetadata())
+          FATAL("The first instruction of the block should include block id, have you instrumented the code with set-counter-BBid-llvm-pass first?");
+        BBid_meta = instr.getMetadata("BBid");
+        break;
+  }
+  std::string meta_string = cast<MDString>(BBid_meta->getOperand(0))->getString();
+  block_counter = std::strtoull(meta_string.c_str(), NULL, 16);//(meta_string,&block_counter,0);
+  if (block_counter == ULLONG_MAX)
+    FATAL("The format of the BBid did not match an unsigned int.");
+  if (block_counter == 0)
+    FATAL("The format of the BBid did not match an unsigned int.");
+  return(block_counter);
+}
+
+
+
 bool AFLCoverage::runOnModule(Module &M) {
 
   LLVMContext &C = M.getContext();
@@ -122,18 +144,9 @@ bool AFLCoverage::runOnModule(Module &M) {
       IRBuilder<> IRB(&(*IP));
 
       /* Make up cur_loc based on block counter */
-
-      MDNode* BBid_meta;
-      for (Instruction& instr : BB.getInstList()) {
-            assert(instr.hasMetadata() && "The first instruction of the block should include block id, have you instrumented the code with set-counter-BBid-llvm-pass first?");
-            BBid_meta = instr.getMetadata("BBid");
-            break;
-      }
-      char c;
-      std::string meta_string = cast<MDString>(BBid_meta->getOperand(0))->getString();
-      std::sscanf(meta_string.c_str(), "%" SCNd64 "%c", &block_counter, &c);
-
-      assert(block_counter < MAP_SIZE && "counter is too large");
+      block_counter = getBBCounter(&BB);
+      if (block_counter > MAP_SIZE)
+        FATAL("counter is too large");
       ConstantInt *CurBB = ConstantInt::get(Int64Ty, block_counter);
 
       /* Load SHM pointer */

--- a/llvm_mode/afl-llvm-pass.so.cc
+++ b/llvm_mode/afl-llvm-pass.so.cc
@@ -91,7 +91,7 @@ u64 getBBCounter(BasicBlock *BB) {
         break;
   }
   std::string meta_string = cast<MDString>(BBid_meta->getOperand(0))->getString();
-  block_counter = std::strtoull(meta_string.c_str(), NULL, 16);//(meta_string,&block_counter,0);
+  block_counter = std::strtoull(meta_string.c_str(), NULL, 16);
   if (block_counter == ULLONG_MAX)
     FATAL("The format of the BBid did not match an unsigned int.");
   if (block_counter == 0)

--- a/llvm_mode/set-counter-BBid-llvm-pass.so.cc
+++ b/llvm_mode/set-counter-BBid-llvm-pass.so.cc
@@ -1,0 +1,79 @@
+#define AFL_LLVM_PASS
+
+#include "../config.h"
+#include "../debug.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <fstream>
+#include<iostream>
+#include <inttypes.h>
+
+#include "llvm/ADT/Statistic.h"
+#include "llvm/IR/IRBuilder.h"
+#include "llvm/IR/LegacyPassManager.h"
+#include "llvm/IR/Module.h"
+#include "llvm/Support/Debug.h"
+#include "llvm/Transforms/IPO/PassManagerBuilder.h"
+
+using namespace llvm;
+
+namespace {
+
+  class CounterBBid : public ModulePass {
+
+    public:
+
+      static char ID;
+      CounterBBid() : ModulePass(ID) { }
+      bool runOnModule(Module &M) override;
+
+  };
+
+}
+char CounterBBid::ID = 0;
+
+bool CounterBBid::runOnModule(Module &M) {
+
+  LLVMContext &C = M.getContext();
+
+  IntegerType *Int64Ty = IntegerType::getInt64Ty(C);
+
+  /* Instrument all the things! */
+
+  u64 block_counter = 1;
+  
+  for (auto &F : M){
+    for (auto &BB : F) {
+
+        assert(block_counter < MAP_SIZE && "counter is too large");
+        std::string value = std::to_string(block_counter);
+        MDString * S = MDString::get(C, value.c_str());
+        MDNode* Meta = MDNode::get(C, S);
+        for (Instruction& instr : BB.getInstList()) {
+            instr.setMetadata("BBid", Meta);
+            break;
+        }
+        block_counter++;
+    }
+  }
+
+  return true;
+
+}
+
+
+static void registerCounterBBidPass(const PassManagerBuilder &,
+                            legacy::PassManagerBase &PM) {
+
+  PM.add(new CounterBBid());
+
+}
+
+
+static RegisterStandardPasses RegisterCounterBBidPass(
+    PassManagerBuilder::EP_ModuleOptimizerEarly, registerCounterBBidPass);
+
+static RegisterStandardPasses RegisterCounterBBidPass0(
+    PassManagerBuilder::EP_EnabledOnOptLevel0, registerCounterBBidPass);

--- a/test_counter_BBid_coverage.c
+++ b/test_counter_BBid_coverage.c
@@ -1,1 +1,0 @@
-test_counter_BBid_coverage.c


### PR DESCRIPTION
Collective coverage script runs the inputs in an input folder on the program and saves the coverage for each in an output folder. It also saves the collective coverage of all inputs in a file specified by the user.